### PR TITLE
Enable bucket and image to be configured

### DIFF
--- a/overture-tiles-cdk/README.md
+++ b/overture-tiles-cdk/README.md
@@ -16,7 +16,7 @@ Overture Tiles CDK creates the AWS infrastructure for generating tiles from Over
   - `npm install -g aws-cdk`
 
 ## Deploying
-- Update configuration in `/lib/config.ts`
+- Update configuration in `bin/overture-tiles-cdk.ts`
 - `npm run cdk bootstrap`
 - `npm run cdk deploy`
 
@@ -25,4 +25,4 @@ Overture Tiles CDK creates the AWS infrastructure for generating tiles from Over
 - Click `Submit new job`
 - Select from the available Job Definitions. Each definition is associated with a version and theme from a past Overture release.
 - Select the OvertureTilesQueue as the Job queue.
-- Submit the job. Once it is complete, it will be available at `s3://IMAGE_NAME/RELEASE/THEME.pmtiles`
+- Submit the job. Once it is complete, it will be available at `s3://BUCKET_NAME/RELEASE/THEME.pmtiles`

--- a/overture-tiles-cdk/README.md
+++ b/overture-tiles-cdk/README.md
@@ -1,8 +1,6 @@
-# Welcome to your CDK TypeScript project
+# Overture Tiles CDK
 
-This is a blank project for CDK development with TypeScript.
-
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+Overture Tiles CDK creates the AWS infrastructure for generating tiles from Overture data.
 
 ## Useful commands
 
@@ -11,3 +9,20 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 * `npx cdk deploy`  deploy this stack to your default AWS account/region
 * `npx cdk diff`    compare deployed stack with current state
 * `npx cdk synth`   emits the synthesized CloudFormation template
+
+## Prerequisites
+- [AWS CLI](https://docs.aws.amazon.com/cli/)
+- [AWS CDK](https://aws.amazon.com/cdk/)
+  - `npm install -g aws-cdk`
+
+## Deploying
+- Update configuration in `/lib/config.ts`
+- `npm run cdk bootstrap`
+- `npm run cdk deploy`
+
+## Tile generation
+- Open the [AWS Batch Jobs console](console.aws.amazon.com/batch/home#jobs)
+- Click `Submit new job`
+- Select from the available Job Definitions. Each definition is associated with a version and theme from a past Overture release.
+- Select the OvertureTilesQueue as the Job queue.
+- Submit the job. Once it is complete, it will be available at `s3://IMAGE_NAME/RELEASE/THEME.pmtiles`

--- a/overture-tiles-cdk/bin/overture-tiles-cdk.ts
+++ b/overture-tiles-cdk/bin/overture-tiles-cdk.ts
@@ -1,10 +1,20 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
-import { OvertureTilesCdkStack } from '../lib/overture-tiles-cdk-stack';
+import {
+  OvertureTilesCdkStack,
+  OvertureTilesCdkStackProps
+} from '../lib/overture-tiles-cdk-stack';
+
+const props: OvertureTilesCdkStackProps = {
+  bucketName: 'overturemaps-tiles-us-west-2-beta',
+  imageName: 'protomaps/overture-tiles:latest',
+}
 
 const app = new cdk.App();
 new OvertureTilesCdkStack(app, 'OvertureTilesCdkStack', {
+  ...props,
+
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/overture-tiles-cdk/lib/overture-tiles-cdk-stack.ts
+++ b/overture-tiles-cdk/lib/overture-tiles-cdk-stack.ts
@@ -10,8 +10,13 @@ import { aws_iam as iam } from "aws-cdk-lib";
 
 const ID = "OvertureTiles";
 
+export type OvertureTilesCdkStackProps = cdk.StackProps & {
+  imageName: string;
+  bucketName: string;
+}
+
 export class OvertureTilesCdkStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: OvertureTilesCdkStackProps) {
     super(scope, id, props);
 
     const userData = ec2.UserData.forLinux();
@@ -36,7 +41,7 @@ export class OvertureTilesCdkStack extends cdk.Stack {
     });
 
     const bucket = new s3.Bucket(this, `${ID}Bucket`, {
-      bucketName: 'overturemaps-tiles-us-west-2-beta',
+      bucketName: props.bucketName,
       blockPublicAccess: new s3.BlockPublicAccess({
         blockPublicAcls: false,
         blockPublicPolicy: false,
@@ -86,7 +91,7 @@ export class OvertureTilesCdkStack extends cdk.Stack {
           `${ID}Container_${theme}`,
           {
             image: ecs.ContainerImage.fromRegistry(
-              "protomaps/overture-tiles:latest",
+             props.imageName,
             ),
             memory: cdk.Size.gibibytes(60),
             cpu: 30,


### PR DESCRIPTION
This PR makes the bucket and image name configurable in the Overture Tiles CDK stack. This enables folks to deploy the stack to other AWS accounts.