### PR TITLE
Add missing attributes to visible land-cover features

### DIFF
--- a/profiles/Base.java
+++ b/profiles/Base.java
@@ -36,9 +36,10 @@ public class Base implements OvertureProfile.Theme {
             OvertureProfile.addFullTags(source, feature, MAXZOOM);
         } else if (layer.equals("land_cover")) {
             var cartography = source.getStruct("cartography");
+            var minZoom = cartography.get("min_zoom").asInt();
             feature.setMaxZoom(cartography.get("max_zoom").asInt());
-            feature.setMinZoom(cartography.get("min_zoom").asInt());
-            OvertureProfile.addFullTags(source, feature, MAXZOOM);
+            feature.setMinZoom(minZoom);
+            OvertureProfile.addFullTags(source, feature, minZoom);
         } else if (layer.equals("water")) {
             int minzoom = 13;
             if (source.isPoint()) {


### PR DESCRIPTION
Fixes https://github.com/OvertureMaps/overture-tiles/issues/25 by ensuring that any visible land cover feature contains a the subtype attribute which is used for coloring on the explore site. This change increases the total size of the `base` tiles from 116.9 GB to 123.9 GB. I'm open to only including the `subtype` attribute if we want to further save space.

#### Before
<img width="1512" alt="Screenshot 2024-09-22 at 7 06 04 PM" src="https://github.com/user-attachments/assets/0177544f-9008-4b07-83b5-40ddd4634511">

#### After
<img width="1510" alt="Screenshot 2024-09-22 at 7 04 06 PM" src="https://github.com/user-attachments/assets/0dd84665-d524-4375-8b29-1f093aa56371">
