### PR TITLE
Add bathymetry layer to base pmtiles

### DIFF
--- a/profiles/Base.java
+++ b/profiles/Base.java
@@ -25,6 +25,10 @@ public class Base implements OvertureProfile.Theme {
             }
             feature.setMinZoom(minzoom);
             OvertureProfile.addFullTags(source, feature, MAXZOOM);
+        }  else if (layer.equals("bathymetry")) {
+            feature.setMinPixelSize(0);
+            feature.setMinZoom(0);
+            OvertureProfile.addFullTags(source, feature, MAXZOOM);
         } else if (layer.equals("land_use")) {
             int minzoom = 9;
             if (source.isPoint()) {


### PR DESCRIPTION
This PR adds the bathymetry data to the base theme PMTiles. The Overture base profile for Planetiler is updated.
<img width="1512" alt="Screenshot 2025-05-28 at 11 02 16 PM" src="https://github.com/user-attachments/assets/1ef3360b-72a2-408b-806d-e26aebf37309" />


This code has already been updated in the ECR image and used during the last two Overture tile releases. Just making sure it gets merged!