### PR TITLE
docs: update documentation with published image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> A pre-built image is available at `public.ecr.aws/y1b4e9z6/overture-tiles:latest`
+
 # Overture Tiles
 Create tilesets from [Overture Maps](http://overturemaps.org) data.
 


### PR DESCRIPTION
Added public ECR image (`public.ecr.aws/y1b4e9z6/overture-tiles:latest`) to `README` for users who prefer not to build locally.