### PR TITLE
Pick up latest release version via STAC catalog in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,46 +1,46 @@
 #!/usr/bin/env just --justfile
 
 cdk_dir := 'overture-tiles-cdk'
-latest_release := `curl -s https://stac.overturemaps.org | jq -r '.links[] | select(.latest == true) | .href | split("/")[1]'`
+latest_release := `curl -s https://stac.overturemaps.org | jq -r '.latest'`
 overture_bucket := 's3://overturemaps-us-west-2'
 
 @_default:
-    {{just_executable()}} --list
+    {{ just_executable() }} --list
 
 # Bootstrap the CDK environment
 [group('setup')]
 bootstrap-cdk:
-    cd {{cdk_dir}} && npm install && npm run build
+    cd {{ cdk_dir }} && npm install && npm run build
 
 # Deploy the CDK stack
 [group('setup')]
 deploy-cdk bucket_name account region create_bucket='false':
-    cd {{cdk_dir}} && npm run cdk deploy -- \
-        -c bucketName={{bucket_name}} \
-        -c account={{account}} \
-        -c region={{region}} \
-        -c createBucket={{create_bucket}}
+    cd {{ cdk_dir }} && npm run cdk deploy -- \
+        -c bucketName={{ bucket_name }} \
+        -c account={{ account }} \
+        -c region={{ region }} \
+        -c createBucket={{ create_bucket }}
 
 # Destroy the CDK stack
 [group('setup')]
 destroy-cdk account region bucket_name='' delete_bucket='false':
-    cd {{cdk_dir}} && npm run cdk destroy -- \
-        -c bucketName={{bucket_name}} \
-        -c account={{account}} \
-        -c region={{region}} \
-        -c deleteBucket={{delete_bucket}}
+    cd {{ cdk_dir }} && npm run cdk destroy -- \
+        -c bucketName={{ bucket_name }} \
+        -c account={{ account }} \
+        -c region={{ region }} \
+        -c deleteBucket={{ delete_bucket }}
 
 # Run a local test of the Docker container with the city of San Francisco. It skips uploading the generated PMTiles
-[group('test')]
 [arg('theme', pattern='base|transportation|buildings|addresses|places|divisions')]
+[group('test')]
 test-local theme='places':
     docker build -t overture-tiles:latest .
     -docker rm -f overture-test 2>/dev/null || true
     docker run --rm --name overture-test \
         -v $(pwd):/data \
-        -e RELEASE='{{latest_release}}' \
+        -e RELEASE='{{ latest_release }}' \
         -e OUTPUT='noop' \
-        -e THEME='{{theme}}' \
+        -e THEME='{{ theme }}' \
         -e BBOX='-122.5247,37.7081,-122.3569,37.8324' \
         -e SKIP_UPLOAD='true' \
         overture-tiles:latest


### PR DESCRIPTION
Overture Maps now publishes STAC catalogs. The `latest_release` variable in `justfile` now dynamically fetches from the catalog instead of being hardcoded.