### PR TITLE
[CHORE] Use ubuntu-22.04-arm runner in workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push:
     name: Build and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
 
     permissions:
       contents: read


### PR DESCRIPTION
Update the GitHub Actions workflow to run on the ubuntu-22.04-arm runner instead of ubuntu-latest to target ARM builds. Also add a trailing newline at the end of the file (minor formatting fix).

See prior test run [here](https://github.com/OvertureMaps/overture-tiles/actions/runs/22000526389/job/63571700216)

Approx. speed improvement for building: 

| Before | After | Delta |
| -- | -- | -- |
| ~30m | ~5m | > 80% |