### PR TITLE
[FIX] Support both WKB and native geometry in places tiles generation

### DIFF
--- a/scripts/places.sh
+++ b/scripts/places.sh
@@ -9,7 +9,11 @@ load spatial;
 COPY ( 
     SELECT
         'Feature' AS type,
-        ST_AsGeoJSON(ST_GeomFromWKB(geometry))) AS geometry,
+        CASE 
+            WHEN typeof(geometry) = 'BLOB' 
+            THEN ST_AsGeoJSON(ST_GeomFromWKB(geometry::BLOB))
+            ELSE ST_AsGeoJSON(geometry::GEOMETRY)
+        END AS geometry,
         json_object(
             'id', id,
             '@name', json_extract_string(names, '$.primary'),


### PR DESCRIPTION
## Closes https://github.com/OvertureMaps/tf-data-platform/issues/3027

## Changes
- Add support for both WKB (`'BLOB'`) and native geometry (`'GEOMETRY'`) data types as input for places tiles generation

The `theme_stage` output of places is currently `WKB`, but the tiles generation script is expecting native geometry. This will support either input.

## Testing
Tested tiles container locally on latest release (`'GEOMETRY'`) with `just` and tested CASE statement on latest places data (`'BLOB'`) with DuckDB