### PR TITLE
[BUG](ci) Fix broken Docker Publish workflow + storage tweak

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,24 +46,20 @@ jobs:
       - name: Extract version from release tag
         id: version
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           # Extract version from tag (e.g., v1.0.0 -> 1.0.0)
           TAG_NAME="${GITHUB_EVENT_RELEASE_TAG_NAME}"
           VERSION="${TAG_NAME#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Release version: ${VERSION}"
-        env:
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Set lowercase repository
         id: lowercase
         env:
-          REPO: ${{ github.repository }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           echo "repository=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/run.sh
+++ b/run.sh
@@ -55,6 +55,9 @@ fi
 className="${THEME^}"
 java -XX:MaxRAMPercentage=70 -cp planetiler.jar /profiles/$className.java --data=/data
 
+# Remove downloaded parquet files — storage may be shared across containers on the same EC2 instance
+rm -rf /data/theme=$THEME /tmp/overture_source
+
 if [ "$SKIP_UPLOAD" != "true" ]; then
   [[ "$OUTPUT" != */ ]] && OUTPUT="${OUTPUT}/"
   AWS_REGION="$S3_REGION" s5cmd cp /data/$THEME.pmtiles "$OUTPUT"


### PR DESCRIPTION
Fixes the broken publishing workflow, which had duplicated `env` blocks that caused it to not be usable.

✨ Bonus - explicitly remove source files post tile generation, to reduce net storage requirements in the context when this container is run in parallel via AWS Batch and may be sharing its storage with other tile generation tasks.