### PR TITLE
[FEATURE] Bake release version into Docker image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -72,6 +72,8 @@ jobs:
           push: true
           provenance: mode=max  # SLSA provenance attestation manifest stored in registry
           sbom: true            # SPDX SBOM attestation manifest stored in registry
+          build-args: |
+            TILES_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/${{ steps.lowercase.outputs.repository }}:latest
             ghcr.io/${{ steps.lowercase.outputs.repository }}:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ ARG TARGETARCH
 ARG DUCKDB_VERSION=1.5.1
 ARG PLANETILER_VERSION=0.10.2
 ARG S5CMD_VERSION=2.3.0
+ARG TILES_VERSION=dev
 
 LABEL org.opencontainers.image.title="overture-tiles"
+
+ENV TILES_VERSION=${TILES_VERSION}
 
 RUN dnf install -y gzip tar unzip && dnf clean all && \
     \

--- a/profiles/OvertureProfile.java
+++ b/profiles/OvertureProfile.java
@@ -74,7 +74,7 @@ public class OvertureProfile implements Profile {
 
     @Override
     public String description() {
-        return "A tileset generated from Overture data";
+        return "tiles.version=" + System.getProperty("tiles.version","dev");
     }
 
     @Override

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,9 @@ fi
 
 # Generate tiles based on theme
 className="${THEME^}"
-java -XX:MaxRAMPercentage=70 -cp planetiler.jar /profiles/$className.java --data=/data
+java -XX:MaxRAMPercentage=70 \
+  -Dtiles.version="${TILES_VERSION:-dev}" \
+  -cp planetiler.jar /profiles/$className.java --data=/data
 
 # Remove downloaded parquet files — storage may be shared across containers on the same EC2 instance
 rm -rf /data/theme=$THEME /tmp/overture_source


### PR DESCRIPTION
Closes #82.

Bakes the GitHub release tag (`TILES_VERSION`) into the Docker image as a runtime env var and forwards it to Planetiler as a JVM system property (`tiles.version`).

@bdon to surface this in the actual PMTiles metadata you'll presumably need to make changes to the java code itself. Feel free to commit into this PR for completeness